### PR TITLE
Support inheritable insecure request policy in documents and workers

### DIFF
--- a/components/constellation/constellation.rs
+++ b/components/constellation/constellation.rs
@@ -1359,6 +1359,7 @@ where
                     Referrer::NoReferrer,
                     ReferrerPolicy::EmptyString,
                     None,
+                    None,
                 );
                 let ctx_id = BrowsingContextId::from(top_level_browsing_context_id);
                 let pipeline_id = match self.browsing_contexts.get(&ctx_id) {
@@ -2999,6 +3000,7 @@ where
             None,
             Referrer::NoReferrer,
             ReferrerPolicy::EmptyString,
+            None,
             None,
         );
         let sandbox = IFrameSandboxState::IFrameUnsandboxed;

--- a/components/net/fetch/methods.rs
+++ b/components/net/fetch/methods.rs
@@ -16,15 +16,15 @@ use headers::{AccessControlExposeHeaders, ContentType, HeaderMapExt};
 use http::header::{self, HeaderMap, HeaderName};
 use http::{HeaderValue, Method, StatusCode};
 use ipc_channel::ipc;
-use log::{debug, warn};
+use log::{debug, trace, warn};
 use mime::{self, Mime};
 use net_traits::filemanager_thread::{FileTokenCheck, RelativePos};
 use net_traits::http_status::HttpStatus;
 use net_traits::policy_container::{PolicyContainer, RequestPolicyContainer};
 use net_traits::request::{
     is_cors_safelisted_method, is_cors_safelisted_request_header, BodyChunkRequest,
-    BodyChunkResponse, CredentialsMode, Destination, Origin, RedirectMode, Referrer, Request,
-    RequestMode, ResponseTainting, Window,
+    BodyChunkResponse, CredentialsMode, Destination, InsecureRequestsPolicy, Origin, RedirectMode,
+    Referrer, Request, RequestMode, ResponseTainting, Window,
 };
 use net_traits::response::{Response, ResponseBody, ResponseType};
 use net_traits::{
@@ -265,6 +265,11 @@ pub async fn main_fetch(
 
     // Step 4.
     if should_upgrade_request_to_potentially_trustworty(request, context) {
+        trace!(
+            "upgrading {} targeting {:?}",
+            request.current_url(),
+            request.destination
+        );
         if let Some(new_scheme) = match request.current_url().scheme() {
             "http" => Some("https"),
             "ws" => Some("wss"),
@@ -276,6 +281,13 @@ pub async fn main_fetch(
                 .set_scheme(new_scheme)
                 .unwrap();
         }
+    } else {
+        trace!(
+            "not upgrading {} targeting {:?} with {:?}",
+            request.current_url(),
+            request.destination,
+            request.insecure_requests_policy
+        );
     }
 
     // Step 5.
@@ -907,6 +919,28 @@ fn should_upgrade_request_to_potentially_trustworty(
     request: &mut Request,
     context: &FetchContext,
 ) -> bool {
+    struct DoNotUpgrade;
+
+    fn should_upgrade_navigation_request(request: &Request) -> Option<DoNotUpgrade> {
+        // Step 2.1 If request is a form submission, skip the remaining substeps, and continue upgrading request.
+        let content_type = request.headers.typed_get::<ContentType>();
+        if content_type.is_some_and(|ct| {
+            let mime: Mime = ct.clone().into();
+            mime.type_() == mime::APPLICATION && mime.subtype() == mime::WWW_FORM_URLENCODED
+        }) {
+            return None;
+        }
+
+        // Step 2.2
+        // TODO If request’s client's target browsing context is a nested browsing context
+
+        // Step 2.4
+        // TODO : check for insecure navigation set after its implemention
+
+        // Step 2.5 Return without further modifying request
+        Some(DoNotUpgrade)
+    }
+
     // Step 1. If request is a navigation request,
     if request.is_navigation_request() {
         // Append a header named Upgrade-Insecure-Requests with a value of 1 to
@@ -927,26 +961,11 @@ fn should_upgrade_request_to_potentially_trustworty(
                 .insert("Upgrade-Insecure-Requests", HeaderValue::from_static("1"));
         }
 
-        // Step 2.1 If request is a form submission, skip the remaining substeps, and continue upgrading request.
-        let content_type = request.headers.typed_get::<ContentType>();
-        if content_type.is_some_and(|ct| {
-            let mime: Mime = ct.clone().into();
-            mime.type_() == mime::APPLICATION && mime.subtype() == mime::WWW_FORM_URLENCODED
-        }) {
-            return true;
+        if let Some(DoNotUpgrade) = should_upgrade_navigation_request(request) {
+            return false;
         }
-
-        // Step 2.2
-        // TODO If request’s client's target browsing context is a nested browsing context
-
-        // Step 2.4
-        // TODO : check for insecure navigation set after its implemention
-
-        // Step 2.5 Return without further modifying request
-        return false;
     }
 
     // Step 4
-    // TODO : add check for insecure requests for client
-    false
+    request.insecure_requests_policy == InsecureRequestsPolicy::Upgrade
 }

--- a/components/script/dom/dedicatedworkerglobalscope.rs
+++ b/components/script/dom/dedicatedworkerglobalscope.rs
@@ -17,7 +17,8 @@ use js::jsval::UndefinedValue;
 use js::rust::{CustomAutoRooter, CustomAutoRooterGuard, HandleValue};
 use net_traits::image_cache::ImageCache;
 use net_traits::request::{
-    CredentialsMode, Destination, ParserMetadata, Referrer, RequestBuilder, RequestMode,
+    CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata, Referrer, RequestBuilder,
+    RequestMode,
 };
 use net_traits::IpcSend;
 use script_traits::{WorkerGlobalScopeInit, WorkerScriptLoadOrigin};
@@ -252,6 +253,7 @@ impl DedicatedWorkerGlobalScope {
         browsing_context: Option<BrowsingContextId>,
         #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
         control_receiver: Receiver<DedicatedWorkerControlMsg>,
+        insecure_requests_policy: InsecureRequestsPolicy,
     ) -> DedicatedWorkerGlobalScope {
         DedicatedWorkerGlobalScope {
             workerglobalscope: WorkerGlobalScope::new_inherited(
@@ -264,6 +266,7 @@ impl DedicatedWorkerGlobalScope {
                 closing,
                 #[cfg(feature = "webgpu")]
                 gpu_id_hub,
+                insecure_requests_policy,
             ),
             task_queue: TaskQueue::new(receiver, own_sender.clone()),
             own_sender,
@@ -291,6 +294,7 @@ impl DedicatedWorkerGlobalScope {
         browsing_context: Option<BrowsingContextId>,
         #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
         control_receiver: Receiver<DedicatedWorkerControlMsg>,
+        insecure_requests_policy: InsecureRequestsPolicy,
     ) -> DomRoot<DedicatedWorkerGlobalScope> {
         let cx = runtime.cx();
         let scope = Box::new(DedicatedWorkerGlobalScope::new_inherited(
@@ -309,6 +313,7 @@ impl DedicatedWorkerGlobalScope {
             #[cfg(feature = "webgpu")]
             gpu_id_hub,
             control_receiver,
+            insecure_requests_policy,
         ));
         unsafe { DedicatedWorkerGlobalScopeBinding::Wrap(SafeJSContext::from_ptr(cx), scope) }
     }
@@ -332,6 +337,7 @@ impl DedicatedWorkerGlobalScope {
         #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
         control_receiver: Receiver<DedicatedWorkerControlMsg>,
         context_sender: Sender<ThreadSafeJSContext>,
+        insecure_requests_policy: InsecureRequestsPolicy,
     ) -> JoinHandle<()> {
         let serialized_worker_url = worker_url.to_string();
         let top_level_browsing_context_id = TopLevelBrowsingContextId::installed();
@@ -369,6 +375,7 @@ impl DedicatedWorkerGlobalScope {
                     .use_url_credentials(true)
                     .pipeline_id(Some(pipeline_id))
                     .referrer_policy(referrer_policy)
+                    .insecure_requests_policy(insecure_requests_policy)
                     .origin(origin);
 
                 let runtime = unsafe {
@@ -420,6 +427,7 @@ impl DedicatedWorkerGlobalScope {
                     #[cfg(feature = "webgpu")]
                     gpu_id_hub,
                     control_receiver,
+                    insecure_requests_policy,
                 );
                 // FIXME(njn): workers currently don't have a unique ID suitable for using in reporter
                 // registration (#6631), so we instead use a random number and cross our fingers.

--- a/components/script/dom/domimplementation.rs
+++ b/components/script/dom/domimplementation.rs
@@ -105,6 +105,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             DocumentActivity::Inactive,
             DocumentSource::NotFromParser,
             loader,
+            Some(self.document.insecure_requests_policy()),
         );
         // Step 2-3.
         let maybe_elem = if qname.is_empty() {
@@ -165,6 +166,7 @@ impl DOMImplementationMethods<crate::DomTypeHolder> for DOMImplementation {
             None,
             Default::default(),
             false,
+            Some(self.document.insecure_requests_policy()),
             can_gc,
         );
 

--- a/components/script/dom/domparser.rs
+++ b/components/script/dom/domparser.rs
@@ -88,6 +88,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     None,
                     Default::default(),
                     false,
+                    Some(doc.insecure_requests_policy()),
                     can_gc,
                 );
                 ServoParser::parse_html_document(&document, Some(s), url, can_gc);
@@ -110,6 +111,7 @@ impl DOMParserMethods<crate::DomTypeHolder> for DOMParser {
                     None,
                     Default::default(),
                     false,
+                    Some(doc.insecure_requests_policy()),
                     can_gc,
                 );
                 ServoParser::parse_xml_document(&document, Some(s), url, can_gc);

--- a/components/script/dom/eventsource.rs
+++ b/components/script/dom/eventsource.rs
@@ -559,6 +559,7 @@ impl EventSourceMethods<crate::DomTypeHolder> for EventSource {
             Some(cors_attribute_state),
             Some(true),
             global.get_referrer(),
+            global.insecure_requests_policy(),
         )
         .origin(global.origin().immutable().clone())
         .pipeline_id(Some(global.pipeline_id()));

--- a/components/script/dom/globalscope.rs
+++ b/components/script/dom/globalscope.rs
@@ -46,7 +46,7 @@ use net_traits::filemanager_thread::{
 };
 use net_traits::image_cache::ImageCache;
 use net_traits::policy_container::PolicyContainer;
-use net_traits::request::{Referrer, RequestBuilder};
+use net_traits::request::{InsecureRequestsPolicy, Referrer, RequestBuilder};
 use net_traits::response::HttpsState;
 use net_traits::{
     fetch_async, CoreResourceMsg, CoreResourceThread, FetchResponseListener, IpcSend,
@@ -2417,6 +2417,18 @@ impl GlobalScope {
     /// Extract a `Window`, panic if the global object is not a `Window`.
     pub(crate) fn as_window(&self) -> &Window {
         self.downcast::<Window>().expect("expected a Window scope")
+    }
+
+    /// Returns a policy that should be used for fetches initiated from this global.
+    pub(crate) fn insecure_requests_policy(&self) -> InsecureRequestsPolicy {
+        if let Some(window) = self.downcast::<Window>() {
+            return window.Document().insecure_requests_policy();
+        }
+        if let Some(worker) = self.downcast::<WorkerGlobalScope>() {
+            return worker.insecure_requests_policy();
+        }
+        debug!("unsupported global, defaulting insecure requests policy to DoNotUpgrade");
+        InsecureRequestsPolicy::DoNotUpgrade
     }
 
     /// <https://html.spec.whatwg.org/multipage/#report-the-error>

--- a/components/script/dom/htmlformelement.rs
+++ b/components/script/dom/htmlformelement.rs
@@ -858,6 +858,7 @@ impl HTMLFormElement {
             target_window.as_global_scope().get_referrer(),
             target_document.get_referrer_policy(),
             Some(target_window.as_global_scope().is_secure_context()),
+            Some(target_document.insecure_requests_policy()),
         );
 
         // Step 22

--- a/components/script/dom/htmliframeelement.rs
+++ b/components/script/dom/htmliframeelement.rs
@@ -267,6 +267,7 @@ impl HTMLIFrameElement {
                 window.as_global_scope().get_referrer(),
                 document.get_referrer_policy(),
                 Some(window.as_global_scope().is_secure_context()),
+                Some(document.insecure_requests_policy()),
             );
             let element = self.upcast::<Element>();
             load_data.srcdoc = String::from(element.get_string_attribute(&local_name!("srcdoc")));
@@ -357,6 +358,7 @@ impl HTMLIFrameElement {
             window.as_global_scope().get_referrer(),
             referrer_policy,
             Some(window.as_global_scope().is_secure_context()),
+            Some(document.insecure_requests_policy()),
         );
 
         let pipeline_id = self.pipeline_id();
@@ -401,6 +403,7 @@ impl HTMLIFrameElement {
             window.as_global_scope().get_referrer(),
             document.get_referrer_policy(),
             Some(window.as_global_scope().is_secure_context()),
+            Some(document.insecure_requests_policy()),
         );
         let browsing_context_id = BrowsingContextId::new();
         let top_level_browsing_context_id = window.window_proxy().top_level_browsing_context_id();

--- a/components/script/dom/htmlimageelement.rs
+++ b/components/script/dom/htmlimageelement.rs
@@ -27,7 +27,8 @@ use net_traits::image_cache::{
     PendingImageResponse, UsePlaceholder,
 };
 use net_traits::request::{
-    CorsSettings, Destination, Initiator, Referrer, RequestBuilder, RequestId,
+    CorsSettings, Destination, Initiator, InsecureRequestsPolicy, Referrer, RequestBuilder,
+    RequestId,
 };
 use net_traits::{
     FetchMetadata, FetchResponseListener, FetchResponseMsg, NetworkError, ReferrerPolicy,
@@ -338,12 +339,19 @@ pub(crate) fn image_fetch_request(
     cors_setting: Option<CorsSettings>,
     referrer_policy: ReferrerPolicy,
     from_picture_or_srcset: FromPictureOrSrcSet,
+    insecure_requests_policy: InsecureRequestsPolicy,
 ) -> RequestBuilder {
-    let mut request =
-        create_a_potential_cors_request(img_url, Destination::Image, cors_setting, None, referrer)
-            .origin(origin)
-            .pipeline_id(Some(pipeline_id))
-            .referrer_policy(referrer_policy);
+    let mut request = create_a_potential_cors_request(
+        img_url,
+        Destination::Image,
+        cors_setting,
+        None,
+        referrer,
+        insecure_requests_policy,
+    )
+    .origin(origin)
+    .pipeline_id(Some(pipeline_id))
+    .referrer_policy(referrer_policy);
     if from_picture_or_srcset == FromPictureOrSrcSet::Yes {
         request = request.initiator(Initiator::ImageSet);
     }
@@ -415,6 +423,7 @@ impl HTMLImageElement {
             } else {
                 FromPictureOrSrcSet::No
             },
+            document.insecure_requests_policy(),
         );
 
         // This is a background load because the load blocker already fulfills the

--- a/components/script/dom/htmllinkelement.rs
+++ b/components/script/dom/htmllinkelement.rs
@@ -13,7 +13,8 @@ use html5ever::{local_name, namespace_url, ns, LocalName, Prefix};
 use js::rust::HandleObject;
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
-    CorsSettings, Destination, Initiator, Referrer, RequestBuilder, RequestId,
+    CorsSettings, Destination, Initiator, InsecureRequestsPolicy, Referrer, RequestBuilder,
+    RequestId,
 };
 use net_traits::{
     FetchMetadata, FetchResponseListener, NetworkError, ReferrerPolicy, ResourceFetchTiming,
@@ -77,6 +78,7 @@ struct LinkProcessingOptions {
     policy_container: PolicyContainer,
     source_set: Option<()>,
     base_url: ServoUrl,
+    insecure_requests_policy: InsecureRequestsPolicy,
     // Some fields that we don't need yet are missing
 }
 
@@ -325,6 +327,7 @@ impl HTMLLinkElement {
             policy_container: document.policy_container().to_owned(),
             source_set: None, // FIXME
             base_url: document.borrow().base_url(),
+            insecure_requests_policy: document.insecure_requests_policy(),
         };
 
         // Step 3. If el has an href attribute, then set options's href to the value of el's href attribute.
@@ -656,6 +659,7 @@ impl LinkProcessingOptions {
             self.cross_origin,
             None,
             Referrer::NoReferrer,
+            self.insecure_requests_policy,
         )
         .integrity_metadata(self.integrity)
         .policy_container(self.policy_container)

--- a/components/script/dom/htmlmediaelement.rs
+++ b/components/script/dom/htmlmediaelement.rs
@@ -888,6 +888,7 @@ impl HTMLMediaElement {
             cors_setting,
             None,
             self.global().get_referrer(),
+            document.insecure_requests_policy(),
         )
         .headers(headers)
         .origin(document.origin().immutable().clone())

--- a/components/script/dom/htmlscriptelement.rs
+++ b/components/script/dom/htmlscriptelement.rs
@@ -21,7 +21,8 @@ use js::jsval::UndefinedValue;
 use js::rust::{transform_str_to_source_text, CompileOptionsWrapper, HandleObject, Stencil};
 use net_traits::http_status::HttpStatus;
 use net_traits::request::{
-    CorsSettings, CredentialsMode, Destination, ParserMetadata, RequestBuilder, RequestId,
+    CorsSettings, CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata,
+    RequestBuilder, RequestId,
 };
 use net_traits::{
     FetchMetadata, FetchResponseListener, Metadata, NetworkError, ResourceFetchTiming,
@@ -547,6 +548,7 @@ pub(crate) fn script_fetch_request(
     origin: ImmutableOrigin,
     pipeline_id: PipelineId,
     options: ScriptFetchOptions,
+    insecure_requests_policy: InsecureRequestsPolicy,
 ) -> RequestBuilder {
     // We intentionally ignore options' credentials_mode member for classic scripts.
     // The mode is initialized by create_a_potential_cors_request.
@@ -556,6 +558,7 @@ pub(crate) fn script_fetch_request(
         cors_setting,
         None,
         options.referrer,
+        insecure_requests_policy,
     )
     .origin(origin)
     .pipeline_id(Some(pipeline_id))
@@ -581,6 +584,7 @@ fn fetch_a_classic_script(
         doc.origin().immutable().clone(),
         script.global().pipeline_id(),
         options.clone(),
+        doc.insecure_requests_policy(),
     );
     let request = doc.prepare_request(request);
 

--- a/components/script/dom/location.rs
+++ b/components/script/dom/location.rs
@@ -129,6 +129,7 @@ impl Location {
             referrer,
             referrer_policy,
             None, // Top navigation doesn't inherit secure context
+            Some(source_document.insecure_requests_policy()),
         );
         self.window
             .load_url(history_handling, reload_triggered, load_data, can_gc);

--- a/components/script/dom/node.rs
+++ b/components/script/dom/node.rs
@@ -2379,6 +2379,7 @@ impl Node {
                     document.status_code(),
                     Default::default(),
                     false,
+                    Some(document.insecure_requests_policy()),
                     can_gc,
                 );
                 DomRoot::upcast::<Node>(document)

--- a/components/script/dom/request.rs
+++ b/components/script/dom/request.rs
@@ -112,6 +112,7 @@ fn net_request_from_global(global: &GlobalScope, url: ServoUrl) -> NetTraitsRequ
         .origin(global.get_url().origin())
         .pipeline_id(Some(global.pipeline_id()))
         .https_state(global.get_https_state())
+        .insecure_requests_policy(global.insecure_requests_policy())
         .build()
 }
 

--- a/components/script/dom/serviceworkerglobalscope.rs
+++ b/components/script/dom/serviceworkerglobalscope.rs
@@ -15,7 +15,9 @@ use ipc_channel::ipc::{IpcReceiver, IpcSender};
 use ipc_channel::router::ROUTER;
 use js::jsapi::{JSContext, JS_AddInterruptCallback};
 use js::jsval::UndefinedValue;
-use net_traits::request::{CredentialsMode, Destination, ParserMetadata, Referrer, RequestBuilder};
+use net_traits::request::{
+    CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata, Referrer, RequestBuilder,
+};
 use net_traits::{CustomResponseMediator, IpcSend};
 use script_traits::{ScopeThings, ServiceWorkerMsg, WorkerGlobalScopeInit, WorkerScriptLoadOrigin};
 use servo_config::pref;
@@ -224,6 +226,8 @@ impl ServiceWorkerGlobalScope {
                 closing,
                 #[cfg(feature = "webgpu")]
                 Arc::new(IdentityHub::default()),
+                // FIXME: investigate what environment this value comes from for service workers.
+                InsecureRequestsPolicy::DoNotUpgrade,
             ),
             task_queue: TaskQueue::new(receiver, own_sender.clone()),
             own_sender,
@@ -341,6 +345,7 @@ impl ServiceWorkerGlobalScope {
                     .use_url_credentials(true)
                     .pipeline_id(Some(pipeline_id))
                     .referrer_policy(referrer_policy)
+                    .insecure_requests_policy(scope.insecure_requests_policy())
                     .origin(origin);
 
                 let (_url, source) = match load_whole_resource(

--- a/components/script/dom/servoparser/mod.rs
+++ b/components/script/dom/servoparser/mod.rs
@@ -216,6 +216,7 @@ impl ServoParser {
             None,
             Default::default(),
             false,
+            Some(context_document.insecure_requests_policy()),
             can_gc,
         );
 

--- a/components/script/dom/websocket.rs
+++ b/components/script/dom/websocket.rs
@@ -257,6 +257,7 @@ impl WebSocketMethods<crate::DomTypeHolder> for WebSocket {
 
         let request = RequestBuilder::new(url_record, Referrer::NoReferrer)
             .origin(global.origin().immutable().clone())
+            .insecure_requests_policy(global.insecure_requests_policy())
             .mode(RequestMode::WebSocket { protocols });
 
         let channels = FetchChannels::WebSocket {

--- a/components/script/dom/windowproxy.rs
+++ b/components/script/dom/windowproxy.rs
@@ -313,6 +313,7 @@ impl WindowProxy {
                 document.global().get_referrer(),
                 document.get_referrer_policy(),
                 None, // Doesn't inherit secure context
+                None,
             );
             let load_info = AuxiliaryBrowsingContextLoadInfo {
                 load_data: load_data.clone(),
@@ -525,6 +526,7 @@ impl WindowProxy {
                 referrer,
                 referrer_policy,
                 Some(secure),
+                Some(target_document.insecure_requests_policy()),
             );
             let history_handling = if new {
                 NavigationHistoryBehavior::Replace

--- a/components/script/dom/worker.rs
+++ b/components/script/dom/worker.rs
@@ -239,6 +239,7 @@ impl WorkerMethods<crate::DomTypeHolder> for Worker {
             global.wgpu_id_hub(),
             control_receiver,
             context_sender,
+            global.insecure_requests_policy(),
         );
 
         let context = context_receiver

--- a/components/script/dom/workerglobalscope.rs
+++ b/components/script/dom/workerglobalscope.rs
@@ -20,7 +20,8 @@ use js::panic::maybe_resume_unwind;
 use js::rust::{HandleValue, MutableHandleValue, ParentRuntime};
 use net_traits::policy_container::PolicyContainer;
 use net_traits::request::{
-    CredentialsMode, Destination, ParserMetadata, RequestBuilder as NetRequestInit,
+    CredentialsMode, Destination, InsecureRequestsPolicy, ParserMetadata,
+    RequestBuilder as NetRequestInit,
 };
 use net_traits::IpcSend;
 use script_traits::WorkerGlobalScopeInit;
@@ -127,6 +128,9 @@ pub(crate) struct WorkerGlobalScope {
     /// Timers are handled in the service worker event loop.
     #[no_trace]
     timer_scheduler: RefCell<TimerScheduler>,
+
+    #[no_trace]
+    insecure_requests_policy: InsecureRequestsPolicy,
 }
 
 impl WorkerGlobalScope {
@@ -140,6 +144,7 @@ impl WorkerGlobalScope {
         devtools_receiver: Receiver<DevtoolScriptControlMsg>,
         closing: Arc<AtomicBool>,
         #[cfg(feature = "webgpu")] gpu_id_hub: Arc<IdentityHub>,
+        insecure_requests_policy: InsecureRequestsPolicy,
     ) -> Self {
         // Install a pipeline-namespace in the current thread.
         PipelineNamespace::auto_install();
@@ -181,7 +186,13 @@ impl WorkerGlobalScope {
             navigation_start: CrossProcessInstant::now(),
             performance: Default::default(),
             timer_scheduler: RefCell::default(),
+            insecure_requests_policy,
         }
+    }
+
+    /// Returns a policy value that should be used by fetches initiated by this worker.
+    pub(crate) fn insecure_requests_policy(&self) -> InsecureRequestsPolicy {
+        self.insecure_requests_policy
     }
 
     /// Clear various items when the worker event-loop shuts-down.
@@ -284,6 +295,7 @@ impl WorkerGlobalScopeMethods<crate::DomTypeHolder> for WorkerGlobalScope {
                 .parser_metadata(ParserMetadata::NotParserInserted)
                 .use_url_credentials(true)
                 .origin(global_scope.origin().immutable().clone())
+                .insecure_requests_policy(self.insecure_requests_policy())
                 .pipeline_id(Some(self.upcast::<GlobalScope>().pipeline_id()));
 
             let (url, source) = match fetch::load_whole_resource(

--- a/components/script/dom/xmldocument.rs
+++ b/components/script/dom/xmldocument.rs
@@ -4,6 +4,7 @@
 
 use dom_struct::dom_struct;
 use mime::Mime;
+use net_traits::request::InsecureRequestsPolicy;
 use script_traits::DocumentActivity;
 use servo_url::{MutableOrigin, ServoUrl};
 
@@ -41,6 +42,7 @@ impl XMLDocument {
         activity: DocumentActivity,
         source: DocumentSource,
         doc_loader: DocumentLoader,
+        inherited_insecure_requests_policy: Option<InsecureRequestsPolicy>,
     ) -> XMLDocument {
         XMLDocument {
             document: Document::new_inherited(
@@ -58,6 +60,7 @@ impl XMLDocument {
                 None,
                 Default::default(),
                 false,
+                inherited_insecure_requests_policy,
             ),
         }
     }
@@ -74,6 +77,7 @@ impl XMLDocument {
         activity: DocumentActivity,
         source: DocumentSource,
         doc_loader: DocumentLoader,
+        inherited_insecure_requests_policy: Option<InsecureRequestsPolicy>,
     ) -> DomRoot<XMLDocument> {
         let doc = reflect_dom_object(
             Box::new(XMLDocument::new_inherited(
@@ -87,6 +91,7 @@ impl XMLDocument {
                 activity,
                 source,
                 doc_loader,
+                inherited_insecure_requests_policy,
             )),
             window,
             CanGc::note(),

--- a/components/script/dom/xmlhttprequest.rs
+++ b/components/script/dom/xmlhttprequest.rs
@@ -691,6 +691,7 @@ impl XMLHttpRequestMethods<crate::DomTypeHolder> for XMLHttpRequest {
         .use_url_credentials(use_url_credentials)
         .origin(self.global().origin().immutable().clone())
         .referrer_policy(self.referrer_policy)
+        .insecure_requests_policy(self.global().insecure_requests_policy())
         .pipeline_id(Some(self.global().pipeline_id()));
 
         // step 4 (second half)
@@ -1520,6 +1521,7 @@ impl XMLHttpRequest {
             None,
             Default::default(),
             false,
+            Some(doc.insecure_requests_policy()),
             can_gc,
         )
     }

--- a/components/script/fetch.rs
+++ b/components/script/fetch.rs
@@ -8,8 +8,8 @@ use std::sync::{Arc, Mutex};
 use ipc_channel::ipc;
 use net_traits::policy_container::RequestPolicyContainer;
 use net_traits::request::{
-    CorsSettings, CredentialsMode, Destination, Referrer, Request as NetTraitsRequest,
-    RequestBuilder, RequestId, RequestMode, ServiceWorkersMode,
+    CorsSettings, CredentialsMode, Destination, InsecureRequestsPolicy, Referrer,
+    Request as NetTraitsRequest, RequestBuilder, RequestId, RequestMode, ServiceWorkersMode,
 };
 use net_traits::{
     cancel_async_fetch, CoreResourceMsg, CoreResourceThread, FetchChannels, FetchMetadata,
@@ -120,6 +120,7 @@ fn request_init_from_request(request: NetTraitsRequest) -> RequestBuilder {
         parser_metadata: request.parser_metadata,
         initiator: request.initiator,
         policy_container: request.policy_container,
+        insecure_requests_policy: request.insecure_requests_policy,
         https_state: request.https_state,
         response_tainting: request.response_tainting,
         crash: None,
@@ -370,6 +371,7 @@ pub(crate) fn create_a_potential_cors_request(
     cors_setting: Option<CorsSettings>,
     same_origin_fallback: Option<bool>,
     referrer: Referrer,
+    insecure_requests_policy: InsecureRequestsPolicy,
 ) -> RequestBuilder {
     RequestBuilder::new(url, referrer)
         // https://html.spec.whatwg.org/multipage/#create-a-potential-cors-request
@@ -388,4 +390,5 @@ pub(crate) fn create_a_potential_cors_request(
         // Step 5
         .destination(destination)
         .use_url_credentials(true)
+        .insecure_requests_policy(insecure_requests_policy)
 }

--- a/components/script/links.rs
+++ b/components/script/links.rs
@@ -425,6 +425,7 @@ pub(crate) fn follow_hyperlink(
             referrer,
             referrer_policy,
             Some(secure),
+            Some(document.insecure_requests_policy()),
         );
         let target = Trusted::new(target_window);
         let task = task!(navigate_follow_hyperlink: move || {

--- a/components/script/navigation.rs
+++ b/components/script/navigation.rs
@@ -13,7 +13,9 @@ use base::id::{BrowsingContextId, PipelineId, TopLevelBrowsingContextId};
 use content_security_policy::Destination;
 use crossbeam_channel::Sender;
 use http::header;
-use net_traits::request::{CredentialsMode, RedirectMode, RequestBuilder, RequestMode};
+use net_traits::request::{
+    CredentialsMode, InsecureRequestsPolicy, RedirectMode, RequestBuilder, RequestMode,
+};
 use net_traits::response::ResponseInit;
 use net_traits::{
     fetch_async, set_default_accept_language, BoxedFetchCallback, CoreResourceThread,
@@ -202,6 +204,11 @@ impl InProgressLoad {
                 .pipeline_id(Some(id))
                 .target_browsing_context_id(Some(top_level_browsing_context_id))
                 .referrer_policy(self.load_data.referrer_policy)
+                .insecure_requests_policy(
+                    self.load_data
+                        .inherited_insecure_requests_policy
+                        .unwrap_or(InsecureRequestsPolicy::DoNotUpgrade),
+                )
                 .headers(self.load_data.headers.clone())
                 .body(self.load_data.data.clone())
                 .redirect_mode(RedirectMode::Manual)

--- a/components/script/script_thread.rs
+++ b/components/script/script_thread.rs
@@ -3193,6 +3193,7 @@ impl ScriptThread {
             Some(metadata.status.raw_code()),
             incomplete.canceller,
             is_initial_about_blank,
+            incomplete.load_data.inherited_insecure_requests_policy,
             can_gc,
         );
 

--- a/components/script/stylesheet_loader.rs
+++ b/components/script/stylesheet_loader.rs
@@ -9,7 +9,9 @@ use base::id::PipelineId;
 use cssparser::SourceLocation;
 use encoding_rs::UTF_8;
 use mime::{self, Mime};
-use net_traits::request::{CorsSettings, Destination, Referrer, RequestBuilder, RequestId};
+use net_traits::request::{
+    CorsSettings, Destination, InsecureRequestsPolicy, Referrer, RequestBuilder, RequestId,
+};
 use net_traits::{
     FetchMetadata, FetchResponseListener, FilteredMetadata, Metadata, NetworkError, ReferrerPolicy,
     ResourceFetchTiming, ResourceTimingType,
@@ -351,6 +353,7 @@ impl StylesheetLoader<'_> {
             self.elem.global().get_referrer(),
             referrer_policy,
             integrity_metadata,
+            document.insecure_requests_policy(),
         );
         let request = document.prepare_request(request);
 
@@ -368,12 +371,20 @@ pub(crate) fn stylesheet_fetch_request(
     referrer: Referrer,
     referrer_policy: ReferrerPolicy,
     integrity_metadata: String,
+    insecure_requests_policy: InsecureRequestsPolicy,
 ) -> RequestBuilder {
-    create_a_potential_cors_request(url, Destination::Style, cors_setting, None, referrer)
-        .origin(origin)
-        .pipeline_id(Some(pipeline_id))
-        .referrer_policy(referrer_policy)
-        .integrity_metadata(integrity_metadata)
+    create_a_potential_cors_request(
+        url,
+        Destination::Style,
+        cors_setting,
+        None,
+        referrer,
+        insecure_requests_policy,
+    )
+    .origin(origin)
+    .pipeline_id(Some(pipeline_id))
+    .referrer_policy(referrer_policy)
+    .integrity_metadata(integrity_metadata)
 }
 
 impl StyleStylesheetLoader for StylesheetLoader<'_> {

--- a/components/shared/net/request.rs
+++ b/components/shared/net/request.rs
@@ -233,6 +233,12 @@ impl RequestBody {
     }
 }
 
+#[derive(Clone, Copy, Debug, Deserialize, MallocSizeOf, PartialEq, Serialize)]
+pub enum InsecureRequestsPolicy {
+    DoNotUpgrade,
+    Upgrade,
+}
+
 #[derive(Clone, Debug, Deserialize, MallocSizeOf, Serialize)]
 pub struct RequestBuilder {
     pub id: RequestId,
@@ -262,6 +268,7 @@ pub struct RequestBuilder {
     pub use_url_credentials: bool,
     pub origin: ImmutableOrigin,
     pub policy_container: RequestPolicyContainer,
+    pub insecure_requests_policy: InsecureRequestsPolicy,
     // XXXManishearth these should be part of the client object
     pub referrer: Referrer,
     pub referrer_policy: ReferrerPolicy,
@@ -298,6 +305,7 @@ impl RequestBuilder {
             use_url_credentials: false,
             origin: ImmutableOrigin::new_opaque(),
             policy_container: RequestPolicyContainer::default(),
+            insecure_requests_policy: InsecureRequestsPolicy::DoNotUpgrade,
             referrer,
             referrer_policy: ReferrerPolicy::EmptyString,
             pipeline_id: None,
@@ -426,6 +434,14 @@ impl RequestBuilder {
         self
     }
 
+    pub fn insecure_requests_policy(
+        mut self,
+        insecure_requests_policy: InsecureRequestsPolicy,
+    ) -> RequestBuilder {
+        self.insecure_requests_policy = insecure_requests_policy;
+        self
+    }
+
     pub fn build(self) -> Request {
         let mut request = Request::new(
             self.id,
@@ -461,6 +477,7 @@ impl RequestBuilder {
         request.response_tainting = self.response_tainting;
         request.crash = self.crash;
         request.policy_container = self.policy_container;
+        request.insecure_requests_policy = self.insecure_requests_policy;
         request.target_browsing_context_id = self.target_browsing_context_id;
         request
     }
@@ -533,6 +550,8 @@ pub struct Request {
     pub parser_metadata: ParserMetadata,
     /// <https://fetch.spec.whatwg.org/#concept-request-policy-container>
     pub policy_container: RequestPolicyContainer,
+    /// <https://w3c.github.io/webappsec-upgrade-insecure-requests/#insecure-requests-policy>
+    pub insecure_requests_policy: InsecureRequestsPolicy,
     pub https_state: HttpsState,
     /// Servo internal: if crash details are present, trigger a crash error page with these details.
     pub crash: Option<String>,
@@ -577,6 +596,7 @@ impl Request {
             redirect_count: 0,
             response_tainting: ResponseTainting::Basic,
             policy_container: RequestPolicyContainer::Client,
+            insecure_requests_policy: InsecureRequestsPolicy::DoNotUpgrade,
             https_state,
             crash: None,
         }

--- a/components/shared/script/lib.rs
+++ b/components/shared/script/lib.rs
@@ -45,7 +45,7 @@ use malloc_size_of::malloc_size_of_is_0;
 use malloc_size_of_derive::MallocSizeOf;
 use media::WindowGLContext;
 use net_traits::image_cache::ImageCache;
-use net_traits::request::{Referrer, RequestBody};
+use net_traits::request::{InsecureRequestsPolicy, Referrer, RequestBody};
 use net_traits::storage_thread::StorageType;
 use net_traits::{ReferrerPolicy, ResourceThreads};
 use pixels::{Image, PixelFormat};
@@ -161,6 +161,8 @@ pub struct LoadData {
     pub srcdoc: String,
     /// The inherited context is Secure, None if not inherited
     pub inherited_secure_context: Option<bool>,
+    /// The inherited policy for upgrading insecure requests; None if not inherited.
+    pub inherited_insecure_requests_policy: Option<InsecureRequestsPolicy>,
 
     /// Servo internal: if crash details are present, trigger a crash error page with these details.
     pub crash: Option<String>,
@@ -185,6 +187,7 @@ impl LoadData {
         referrer: Referrer,
         referrer_policy: ReferrerPolicy,
         inherited_secure_context: Option<bool>,
+        inherited_insecure_requests_policy: Option<InsecureRequestsPolicy>,
     ) -> LoadData {
         LoadData {
             load_origin,
@@ -199,6 +202,7 @@ impl LoadData {
             srcdoc: "".to_string(),
             inherited_secure_context,
             crash: None,
+            inherited_insecure_requests_policy,
         }
     }
 }

--- a/components/webdriver_server/lib.rs
+++ b/components/webdriver_server/lib.rs
@@ -668,6 +668,7 @@ impl Handler {
             Referrer::NoReferrer,
             ReferrerPolicy::EmptyString,
             None,
+            None,
         );
         let cmd_msg = WebDriverCommandMsg::LoadUrl(
             top_level_browsing_context_id,


### PR DESCRIPTION
These changes allow the /upgrade-insecure-requests tests for XHR, Fetch, `<img>`, and workers to pass. Websockets fail due to #35028, and tests that rely on iframes fail because of the missing step about nested contexts.